### PR TITLE
Animation directions changed to opposite

### DIFF
--- a/fragmentanimations/src/main/java/com/labo/kaji/fragmentanimations/CubeAnimation.java
+++ b/fragmentanimations/src/main/java/com/labo/kaji/fragmentanimations/CubeAnimation.java
@@ -60,14 +60,14 @@ public class CubeAnimation extends ViewPropertyAnimation {
         public void initialize(int width, int height, int parentWidth, int parentHeight) {
             super.initialize(width, height, parentWidth, parentHeight);
             mPivotX = width * 0.5f;
-            mPivotY = (mEnter == (mDirection == UP)) ? 0.0f : height;
+            mPivotY = (mEnter == (mDirection == DOWN)) ? 0.0f : height;
             mCameraZ = -height * 0.015f;
         }
 
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             float value = mEnter ? (interpolatedTime - 1.0f) : interpolatedTime;
-            if (mDirection == DOWN) value *= -1.0f;
+            if (mDirection == UP) value *= -1.0f;
             mRotationX = value * 90.0f;
             mTranslationY = -value * mHeight;
 
@@ -86,7 +86,7 @@ public class CubeAnimation extends ViewPropertyAnimation {
         @Override
         public void initialize(int width, int height, int parentWidth, int parentHeight) {
             super.initialize(width, height, parentWidth, parentHeight);
-            mPivotX = (mEnter == (mDirection == LEFT)) ? 0.0f : width;
+            mPivotX = (mEnter == (mDirection == RIGHT)) ? 0.0f : width;
             mPivotY = height * 0.5f;
             mCameraZ = -width * 0.015f;
         }
@@ -94,7 +94,7 @@ public class CubeAnimation extends ViewPropertyAnimation {
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             float value = mEnter ? (interpolatedTime - 1.0f) : interpolatedTime;
-            if (mDirection == RIGHT) value *= -1.0f;
+            if (mDirection == LEFT) value *= -1.0f;
             mRotationY = -value * 90.0f;
             mTranslationX = -value * mWidth;
 

--- a/fragmentanimations/src/main/java/com/labo/kaji/fragmentanimations/FlipAnimation.java
+++ b/fragmentanimations/src/main/java/com/labo/kaji/fragmentanimations/FlipAnimation.java
@@ -60,14 +60,14 @@ public class FlipAnimation extends ViewPropertyAnimation {
         public void initialize(int width, int height, int parentWidth, int parentHeight) {
             super.initialize(width, height, parentWidth, parentHeight);
             mPivotX = width * 0.5f;
-            mPivotY = (mEnter == (mDirection == UP)) ? 0.0f : height;
+            mPivotY = (mEnter == (mDirection == DOWN)) ? 0.0f : height;
             mCameraZ = -height * 0.015f;
         }
 
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             float value = mEnter ? (interpolatedTime - 1.0f) : interpolatedTime;
-            if (mDirection == DOWN) value *= -1.0f;
+            if (mDirection == UP) value *= -1.0f;
             mRotationX = value * 180.0f;
             mTranslationY = -value * mHeight;
 
@@ -94,7 +94,7 @@ public class FlipAnimation extends ViewPropertyAnimation {
         @Override
         public void initialize(int width, int height, int parentWidth, int parentHeight) {
             super.initialize(width, height, parentWidth, parentHeight);
-            mPivotX = (mEnter == (mDirection == LEFT)) ? 0.0f : width;
+            mPivotX = (mEnter == (mDirection == RIGHT)) ? 0.0f : width;
             mPivotY = height * 0.5f;
             mCameraZ = -width * 0.015f;
         }
@@ -102,7 +102,7 @@ public class FlipAnimation extends ViewPropertyAnimation {
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             float value = mEnter ? (interpolatedTime - 1.0f) : interpolatedTime;
-            if (mDirection == RIGHT) value *= -1.0f;
+            if (mDirection == LEFT) value *= -1.0f;
             mRotationY = -value * 180.0f;
             mTranslationX = -value * mWidth;
 

--- a/fragmentanimations/src/main/java/com/labo/kaji/fragmentanimations/MoveAnimation.java
+++ b/fragmentanimations/src/main/java/com/labo/kaji/fragmentanimations/MoveAnimation.java
@@ -59,7 +59,7 @@ public class MoveAnimation extends ViewPropertyAnimation {
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             float value = mEnter ? (interpolatedTime - 1.0f) : interpolatedTime;
-            if (mDirection == DOWN) value *= -1.0f;
+            if (mDirection == UP) value *= -1.0f;
             mTranslationY = -value * mHeight;
 
             super.applyTransformation(interpolatedTime, t);
@@ -77,7 +77,7 @@ public class MoveAnimation extends ViewPropertyAnimation {
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             float value = mEnter ? (interpolatedTime - 1.0f) : interpolatedTime;
-            if (mDirection == RIGHT) value *= -1.0f;
+            if (mDirection == LEFT) value *= -1.0f;
             mTranslationX = -value * mWidth;
 
             super.applyTransformation(interpolatedTime, t);

--- a/fragmentanimations/src/main/java/com/labo/kaji/fragmentanimations/PushPullAnimation.java
+++ b/fragmentanimations/src/main/java/com/labo/kaji/fragmentanimations/PushPullAnimation.java
@@ -60,13 +60,13 @@ public class PushPullAnimation extends ViewPropertyAnimation {
         public void initialize(int width, int height, int parentWidth, int parentHeight) {
             super.initialize(width, height, parentWidth, parentHeight);
             mPivotX = width * 0.5f;
-            mPivotY = (mEnter == (mDirection == DOWN)) ? 0.0f : height;
+            mPivotY = (mEnter == (mDirection == UP)) ? 0.0f : height;
         }
 
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             float value = mEnter ? (interpolatedTime - 1.0f) : interpolatedTime;
-            if (mDirection == UP) value *= -1.0f;
+            if (mDirection == DOWN) value *= -1.0f;
             mRotationX = value * 90.0f;
             mAlpha = mEnter ? interpolatedTime : (1.0f - interpolatedTime);
 
@@ -85,14 +85,14 @@ public class PushPullAnimation extends ViewPropertyAnimation {
         @Override
         public void initialize(int width, int height, int parentWidth, int parentHeight) {
             super.initialize(width, height, parentWidth, parentHeight);
-            mPivotX = (mEnter == (mDirection == RIGHT)) ? 0.0f : width;
+            mPivotX = (mEnter == (mDirection == LEFT)) ? 0.0f : width;
             mPivotY = height * 0.5f;
         }
 
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             float value = mEnter ? (interpolatedTime - 1.0f) : interpolatedTime;
-            if (mDirection == LEFT) value *= -1.0f;
+            if (mDirection == RIGHT) value *= -1.0f;
             mRotationY = -value * 90.0f;
             mAlpha = mEnter ? interpolatedTime : (1.0f - interpolatedTime);
 

--- a/fragmentanimations/src/main/java/com/labo/kaji/fragmentanimations/SidesAnimation.java
+++ b/fragmentanimations/src/main/java/com/labo/kaji/fragmentanimations/SidesAnimation.java
@@ -62,13 +62,13 @@ public class SidesAnimation extends ViewPropertyAnimation {
         public void initialize(int width, int height, int parentWidth, int parentHeight) {
             super.initialize(width, height, parentWidth, parentHeight);
             mPivotX = width * 0.5f;
-            mPivotY = (mEnter == (mDirection == DOWN)) ? 0.0f : height;
+            mPivotY = (mEnter == (mDirection == UP)) ? 0.0f : height;
         }
 
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             float value = mEnter ? (interpolatedTime - 1.0f) : interpolatedTime;
-            if (mDirection == UP) value *= -1.0f;
+            if (mDirection == DOWN) value *= -1.0f;
             mRotationX = value * 90.0f;
             mAlpha = mEnter ? interpolatedTime : (1.0f - interpolatedTime);
             mTranslationZ = (1.0f - mAlpha) * mWidth;
@@ -88,14 +88,14 @@ public class SidesAnimation extends ViewPropertyAnimation {
         @Override
         public void initialize(int width, int height, int parentWidth, int parentHeight) {
             super.initialize(width, height, parentWidth, parentHeight);
-            mPivotX = (mEnter == (mDirection == RIGHT)) ? 0.0f : width;
+            mPivotX = (mEnter == (mDirection == LEFT)) ? 0.0f : width;
             mPivotY = height * 0.5f;
         }
 
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             float value = mEnter ? (interpolatedTime - 1.0f) : interpolatedTime;
-            if (mDirection == LEFT) value *= -1.0f;
+            if (mDirection == RIGHT) value *= -1.0f;
             mRotationY = -value * 90.0f;
             mAlpha = mEnter ? interpolatedTime : (1.0f - interpolatedTime);
             mTranslationZ = (1.0f - mAlpha) * mHeight;


### PR DESCRIPTION
When clicking left button it hides current fragment to left and opens another from right, which I suppose is incorrect and little bit annoying. It should open new fragment from right when user clicks on right button and from left when user clicks left button, which is logically correct.